### PR TITLE
Allow models from this repo to be loaded via `torch.hub`

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -1,0 +1,6 @@
+# flake8: noqa
+
+from src.attention.models import (AttentionSegmenter, CheaplabLiteSegmenter,
+                                  CheaplabSegmenter, EntropyLoss)
+from src.unsupervised_pretrain.models import (
+    SeriesModel, SeriesResNet18, SeriesEfficientNetb0, SeriesMobileNetv3)


### PR DESCRIPTION
Example:

```py
model = torch.hub.load(
    'AdeelH/geospatial-time-series:hub',
    'SeriesResNet18',
    source='github',
    trust_repo=False,
    pretrained=False,
)
```